### PR TITLE
perf: fix drawer flicker by increasing debounce delay

### DIFF
--- a/apps/nextjs/src/components/features/Tasks/TasksBoard/useTasksBoardDetail.tsx
+++ b/apps/nextjs/src/components/features/Tasks/TasksBoard/useTasksBoardDetail.tsx
@@ -61,7 +61,7 @@ export const useTasksBoardDetail = (props: Props) => {
         loadingShown = true;
         setLoading(true);
       }
-    }, 300);
+    }, 500);
 
     startTransition(async () => {
       await fetchQuery({ taskId: newId });

--- a/apps/nextjs/src/components/features/Tasks/TasksList/useTasksListDetail.tsx
+++ b/apps/nextjs/src/components/features/Tasks/TasksList/useTasksListDetail.tsx
@@ -60,7 +60,7 @@ export const useTasksListDetail = (props: Props) => {
         loadingShown = true;
         setLoading(true);
       }
-    }, 300);
+    }, 500);
 
     startTransition(async () => {
       await fetchQuery({ taskId: newId });


### PR DESCRIPTION
## Summary

This PR fixes a UI flicker issue in the task detail drawer by increasing the debounce delay for the loading state from 300ms to 500ms.

When quickly switching between tasks, the loading indicator was appearing briefly and causing visual flickering. By increasing the debounce delay, the loading state only shows when task fetching actually takes longer, resulting in a smoother user experience.

### Changes
- `useTasksBoardDetail.tsx`: Increased debounce delay from 300ms to 500ms
- `useTasksListDetail.tsx`: Increased debounce delay from 300ms to 500ms

## Related Issues

N/A

## Testing

- Manually verified that rapidly clicking between tasks no longer causes loading indicator flicker
- The drawer transitions smoothly between tasks without showing unnecessary loading states
- Loading indicator still appears appropriately when actual network latency is present