### PR TITLE
fix: expand proxy matcher exclusions

### DIFF
--- a/apps/nextjs/src/proxy.ts
+++ b/apps/nextjs/src/proxy.ts
@@ -44,5 +44,7 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: [
+    '/((?!_next/static|_next/image|favicon\\.ico|manifest\\.json|robots\\.txt|sitemap\\.xml|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|woff2?|ttf)$).*)',
+  ],
 };


### PR DESCRIPTION
## Summary

Updated the proxy matcher configuration to exclude additional static files and assets. This ensures better handling of requests by preventing unnecessary proxying for static resources that should be served directly by Next.js.

### Changes
- Expanded the proxy matcher exclusion pattern to include:
  - `manifest.json`, `robots.txt`, `sitemap.xml` - common static files
  - Image formats: `svg`, `png`, `jpg`, `jpeg`, `gif`, `webp`, `ico`
  - Font formats: `woff`, `woff2`, `ttf`
- Removed `api` from the exclusion pattern (was redundant or not needed)
- Fixed regex escaping for `favicon.ico`

## Related Issues

N/A

## Testing

- Verified that the updated regex pattern correctly matches and excludes the specified file types
- Static assets are served directly without going through the proxy